### PR TITLE
Skip sockets as they cannot be included in archive

### DIFF
--- a/targz.go
+++ b/targz.go
@@ -201,6 +201,10 @@ func writeTarGz(path string, tarWriter *tar.Writer, fileInfo os.FileInfo, subPat
 		}
 	}
 
+	if fileInfo.Mode()&os.ModeSocket == os.ModeSocket {
+		return nil
+	}
+
 	header, err := tar.FileInfoHeader(fileInfo, link)
 	if err != nil {
 		return err


### PR DESCRIPTION
See: https://github.com/offen/docker-volume-backup/issues/58